### PR TITLE
allow client authentication by form data

### DIFF
--- a/token/src/main/java/com/networknt/oauth/token/helper/HttpAuth.java
+++ b/token/src/main/java/com/networknt/oauth/token/helper/HttpAuth.java
@@ -1,0 +1,82 @@
+package com.networknt.oauth.token.helper;
+
+import io.undertow.server.HttpServerExchange;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class HttpAuth {
+    private boolean headerAvailable;
+    private boolean basicAuth = false;
+    private boolean invalidCredentials;
+    private String clientId;
+    private String clientSecret;
+    private String credentials;
+    private String auth;
+
+    public HttpAuth(HttpServerExchange exchange) {
+        process(exchange);
+    }
+
+    private void process(HttpServerExchange exchange) {
+        auth = exchange.getRequestHeaders().getFirst("Authorization");
+        if(auth == null || auth.trim().length() == 0) {
+            headerAvailable = false;
+        } else {
+            headerAvailable = true;
+
+            String basic = auth.substring(0, 5);
+            if("BASIC".equalsIgnoreCase(basic)) {
+                basicAuth = true;
+                credentials = auth.substring(6);
+                int pos = credentials.indexOf(':');
+                if (pos == -1) {
+                    credentials = decodeCredentials(credentials);
+                }
+                pos = credentials.indexOf(':');
+                if (pos != -1) {
+                    clientId = credentials.substring(0, pos);
+                    clientSecret = credentials.substring(pos + 1);
+                    invalidCredentials = false;
+                } else {
+                    invalidCredentials = true;
+                }
+            }
+        }
+    }
+
+    private String decodeCredentials(String cred) {
+        return new String(org.apache.commons.codec.binary.Base64.decodeBase64(cred), UTF_8);
+    }
+
+    public boolean isHeaderAvailable() {
+        return headerAvailable;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public boolean isInvalidCredentials() {
+        return invalidCredentials;
+    }
+
+    public boolean isValid() {
+        return isHeaderAvailable() && !isInvalidCredentials();
+    }
+
+    public boolean isBasicAuth() {
+        return basicAuth;
+    }
+
+    public String getCredentials() {
+        return credentials;
+    }
+
+    public String getAuth() {
+        return auth;
+    }
+}

--- a/token/src/main/resources/config/swagger.json
+++ b/token/src/main/resources/config/swagger.json
@@ -34,7 +34,7 @@
                         "description": "encoded client_id and client_secret pair",
                         "in": "header",
                         "type": "string",
-                        "required": true
+                        "required": false
                     },
                     {
                         "name": "grant_type",
@@ -46,6 +46,18 @@
                             "refresh_token"
                         ],
                         "required": true,
+                        "in": "formData"
+                    },
+                    {
+                        "name": "client_id",
+                        "description": "used as alternative to authentication header for client authentication",
+                        "type": "string",
+                        "in": "formData"
+                    },
+                    {
+                        "name": "client_secret",
+                        "description": "used as alternative to authentication header for client authentication",
+                        "type": "string",
                         "in": "formData"
                     },
                     {

--- a/token/src/test/java/com/networknt/oauth/token/handler/Oauth2TokenPostHandlerTest.java
+++ b/token/src/test/java/com/networknt/oauth/token/handler/Oauth2TokenPostHandlerTest.java
@@ -1,7 +1,6 @@
 package com.networknt.oauth.token.handler;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.hazelcast.core.IMap;
 import com.networknt.config.Config;
 import com.networknt.oauth.cache.CacheStartupHookProvider;
 import com.networknt.oauth.cache.model.RefreshToken;
@@ -71,6 +70,24 @@ public class Oauth2TokenPostHandlerTest {
     }
 
     @Test
+    public void testClientCredentialsTokenByFormData() throws Exception {
+        String url = "http://localhost:6882/oauth2/token";
+        CloseableHttpClient client = HttpClients.createDefault();
+        HttpPost httpPost = new HttpPost(url);
+
+        List<NameValuePair> urlParameters = new ArrayList<>();
+        urlParameters.add(new BasicNameValuePair("grant_type", "client_credentials"));
+        urlParameters.add(new BasicNameValuePair("client_id", "f7d42348-c647-4efb-a52d-4c5787421e72"));
+        urlParameters.add(new BasicNameValuePair("client_secret", "f6h1FTI8Q3-7UScPZDzfXA"));
+        httpPost.setEntity(new UrlEncodedFormEntity(urlParameters));
+        HttpResponse response = client.execute(httpPost);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        String body = EntityUtils.toString(response.getEntity());
+        logger.debug("response body = " + body);
+        Assert.assertTrue(body.indexOf("access_token") > 0);
+    }
+
+    @Test
     public void testTokenInvalidForm() throws Exception {
         String url = "http://localhost:6882/oauth2/token";
         CloseableHttpClient client = HttpClients.createDefault();
@@ -110,11 +127,10 @@ public class Oauth2TokenPostHandlerTest {
         urlParameters.add(new BasicNameValuePair("grant_type", "client_credentials"));
         httpPost.setEntity(new UrlEncodedFormEntity(urlParameters));
         HttpResponse response = client.execute(httpPost);
-        //String body = EntityUtils.toString(response.getEntity());
-        Assert.assertEquals(400, response.getStatusLine().getStatusCode());
+        Assert.assertEquals(401, response.getStatusLine().getStatusCode());
         Status status = Config.getInstance().getMapper().readValue(response.getEntity().getContent(), Status.class);
         Assert.assertNotNull(status);
-        Assert.assertEquals("ERR11017", status.getCode());
+        Assert.assertEquals("ERR12002", status.getCode());
     }
 
     @Test


### PR DESCRIPTION
This PR increases the compatibility to some client implementations which rely on the post parameters "client_id" and "client_secret" instead of providing those as HTTP BASIC AUTH header.