### PR TITLE
New refresh tokens given old key

### DIFF
--- a/token/src/main/java/com/networknt/oauth/token/handler/Oauth2TokenPostHandler.java
+++ b/token/src/main/java/com/networknt/oauth/token/handler/Oauth2TokenPostHandler.java
@@ -428,7 +428,7 @@ public class Oauth2TokenPostHandler extends TokenAuditHandler implements LightHt
                     newToken.setRoles(roles);
                     newToken.setClientId(client.getClientId());
                     newToken.setScope(scope);
-                    tokens.put(refreshToken, newToken);
+                    tokens.put(newRefreshToken, newToken);
                     // if the client type is external, save the jwt to reference map and send the reference
                     if(Client.ClientTypeEnum.EXTERNAL == client.getClientType()) {
                         jwt = jwtReference(jwt, client.getDerefClientId());


### PR DESCRIPTION
New refresh tokens are now keyed by their token string, rather than the token string of the old refresh token in the request. This fix prevents refresh tokens from being re-used. Old refresh tokens are now properly revoked fter a single use.

References issue #215